### PR TITLE
fix: Compilation error on default JDK8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
           "hdfs_3_3",
         ]
 
+    # We set JAVA_HOME and JAVA_HOME_8_ARM64 to ensure compilation works out of the box for all targets
+    # A user can manually specify JAVA_HOME to use their own distribution
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -45,21 +47,6 @@ jobs:
         with:
           distribution: 'corretto'
           java-version: '8'
-
-      # Add jvm.dll in PATH to make sure windows can find it.
-#      - name: Update path for windows
-#        if: matrix.os == 'windows-latest'
-#        run: |
-#          echo "${{ steps.setup_java.outputs.path }}\lib" >> $GITHUB_PATH
-#          echo "${{ steps.setup_java.outputs.path }}\jre\bin\server" >> $GITHUB_PATH
-#          echo "LIB=${LIB};${{ steps.setup_java.outputs.path }}\lib;${{ steps.setup_java.outputs.path }}\jre\bin\server" >> $GITHUB_ENV
-
-      # Add libjvm.dylib in RPATH to make sure macos can find it.
-#      - name: Update path for macos
-#        if: matrix.os == 'macos-latest'
-#        run: |
-#          mkdir -p ~/lib
-#          ln -s ${{ steps.setup_java.outputs.path }}/jre/lib/server/libjvm.dylib ~/lib/
 
       - name: Build
         run: cargo build --features ${{ matrix.feature }},vendored

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/setup-java@v4
         id: setup_java
         with:
-          distribution: 'temurin'
+          distribution: 'corretto'
           java-version: '8'
 
       # Add jvm.dll in PATH to make sure windows can find it.
@@ -63,9 +63,12 @@ jobs:
 
       - name: Build
         run: cargo build --features ${{ matrix.feature }}
+        env:
+          JAVA_HOME: ""
       - name: Test
         run: cargo test --features ${{ matrix.feature }} -- --nocapture
         env:
           RUST_LOG: DEBUG
           RUST_BACKTRACE: full
+          JAVA_HOME: ""
 #          LD_LIBRARY_PATH: ${{ env.JAVA_HOME }}/lib/server:${{ env.JAVA_HOME }}/lib/amd64/server:${{ env.JAVA_HOME }}/jre/lib/server:${{ env.JAVA_HOME }}/jre/lib/amd64/server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,8 @@ jobs:
           "hdfs_3_3",
         ]
 
-    # We set JAVA_HOME and JAVA_HOME_8_ARM64 to ensure compilation works out of the box for all targets
+    # We set JAVA_HOME, JAVA_HOME_8_X64 and JAVA_HOME_8_ARM64,
+    # to ensure compilation works out of the box for all targets
     # A user can manually specify JAVA_HOME to use their own distribution
     steps:
       - uses: actions/checkout@v4
@@ -52,6 +53,7 @@ jobs:
         run: cargo build --features ${{ matrix.feature }},vendored
         env:
           JAVA_HOME: ""
+          JAVA_HOME_8_X64: ""
           JAVA_HOME_8_ARM64: ""
 
       - name: Test
@@ -60,4 +62,5 @@ jobs:
           RUST_LOG: DEBUG
           RUST_BACKTRACE: full
           JAVA_HOME: ""
+          JAVA_HOME_8_X64: ""
           JAVA_HOME_8_ARM64: ""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,19 +47,19 @@ jobs:
           java-version: '8'
 
       # Add jvm.dll in PATH to make sure windows can find it.
-      - name: Update path for windows
-        if: matrix.os == 'windows-latest'
-        run: |
-          echo "${{ steps.setup_java.outputs.path }}\lib" >> $GITHUB_PATH
-          echo "${{ steps.setup_java.outputs.path }}\jre\bin\server" >> $GITHUB_PATH
-          echo "LIB=${LIB};${{ steps.setup_java.outputs.path }}\lib;${{ steps.setup_java.outputs.path }}\jre\bin\server" >> $GITHUB_ENV
+#      - name: Update path for windows
+#        if: matrix.os == 'windows-latest'
+#        run: |
+#          echo "${{ steps.setup_java.outputs.path }}\lib" >> $GITHUB_PATH
+#          echo "${{ steps.setup_java.outputs.path }}\jre\bin\server" >> $GITHUB_PATH
+#          echo "LIB=${LIB};${{ steps.setup_java.outputs.path }}\lib;${{ steps.setup_java.outputs.path }}\jre\bin\server" >> $GITHUB_ENV
 
       # Add libjvm.dylib in RPATH to make sure macos can find it.
-      - name: Update path for macos
-        if: matrix.os == 'macos-latest'
-        run: |
-          mkdir -p ~/lib
-          ln -s ${{ steps.setup_java.outputs.path }}/jre/lib/server/libjvm.dylib ~/lib/
+#      - name: Update path for macos
+#        if: matrix.os == 'macos-latest'
+#        run: |
+#          mkdir -p ~/lib
+#          ln -s ${{ steps.setup_java.outputs.path }}/jre/lib/server/libjvm.dylib ~/lib/
 
       - name: Build
         run: cargo build --features ${{ matrix.feature }}
@@ -68,4 +68,4 @@ jobs:
         env:
           RUST_LOG: DEBUG
           RUST_BACKTRACE: full
-          LD_LIBRARY_PATH: ${{ env.JAVA_HOME }}/lib/server:${{ env.JAVA_HOME }}/lib/amd64/server:${{ env.JAVA_HOME }}/jre/lib/server:${{ env.JAVA_HOME }}/jre/lib/amd64/server
+#          LD_LIBRARY_PATH: ${{ env.JAVA_HOME }}/lib/server:${{ env.JAVA_HOME }}/lib/amd64/server:${{ env.JAVA_HOME }}/jre/lib/server:${{ env.JAVA_HOME }}/jre/lib/amd64/server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,18 +55,18 @@ jobs:
 #          echo "LIB=${LIB};${{ steps.setup_java.outputs.path }}\lib;${{ steps.setup_java.outputs.path }}\jre\bin\server" >> $GITHUB_ENV
 
       # Add libjvm.dylib in RPATH to make sure macos can find it.
-#      - name: Update path for macos
-#        if: matrix.os == 'macos-latest'
-#        run: |
-#          mkdir -p ~/lib
-#          ln -s ${{ steps.setup_java.outputs.path }}/jre/lib/server/libjvm.dylib ~/lib/
+      - name: Update path for macos
+        if: matrix.os == 'macos-latest'
+        run: |
+          mkdir -p ~/lib
+          ln -s ${{ steps.setup_java.outputs.path }}/jre/lib/server/libjvm.dylib ~/lib/
 
       - name: Build
-        run: cargo build --features ${{ matrix.feature }}
+        run: cargo build --features ${{ matrix.feature }},vendored
         env:
           JAVA_HOME: ""
       - name: Test
-        run: cargo test --features ${{ matrix.feature }} -- --nocapture
+        run: cargo test --features ${{ matrix.feature }},vendored -- --nocapture
         env:
           RUST_LOG: DEBUG
           RUST_BACKTRACE: full

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,20 +55,22 @@ jobs:
 #          echo "LIB=${LIB};${{ steps.setup_java.outputs.path }}\lib;${{ steps.setup_java.outputs.path }}\jre\bin\server" >> $GITHUB_ENV
 
       # Add libjvm.dylib in RPATH to make sure macos can find it.
-      - name: Update path for macos
-        if: matrix.os == 'macos-latest'
-        run: |
-          mkdir -p ~/lib
-          ln -s ${{ steps.setup_java.outputs.path }}/jre/lib/server/libjvm.dylib ~/lib/
+#      - name: Update path for macos
+#        if: matrix.os == 'macos-latest'
+#        run: |
+#          mkdir -p ~/lib
+#          ln -s ${{ steps.setup_java.outputs.path }}/jre/lib/server/libjvm.dylib ~/lib/
 
       - name: Build
         run: cargo build --features ${{ matrix.feature }},vendored
         env:
           JAVA_HOME: ""
+          JAVA_HOME_8_ARM64: ""
+
       - name: Test
         run: cargo test --features ${{ matrix.feature }},vendored -- --nocapture
         env:
           RUST_LOG: DEBUG
           RUST_BACKTRACE: full
           JAVA_HOME: ""
-#          LD_LIBRARY_PATH: ${{ env.JAVA_HOME }}/lib/server:${{ env.JAVA_HOME }}/lib/amd64/server:${{ env.JAVA_HOME }}/jre/lib/server:${{ env.JAVA_HOME }}/jre/lib/amd64/server
+          JAVA_HOME_8_ARM64: ""

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,4 +33,4 @@ vendored = []
 
 [build-dependencies]
 cc = "1"
-java-locator = "0.1"
+java-locator = { version =  "0.1.9", features = ["locate-jdk-only"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ hdfs_3_1 = ["hdfs_3_0"]
 hdfs_3_2 = ["hdfs_3_1"]
 hdfs_3_3 = ["hdfs_3_2"]
 
-vendored = []
+vendored = ["java-locator/locate-jdk-only"] # JRE is not enough for building, we need the JDK
 
 [build-dependencies]
 cc = "1"
-java-locator = { version =  "0.1.9", features = ["locate-jdk-only"] }
+java-locator = "0.1"

--- a/build.rs
+++ b/build.rs
@@ -28,6 +28,8 @@ fn find_jvm() -> Result<()> {
     println!("cargo:rustc-link-lib=jvm");
     println!("cargo:rustc-link-search=native={jvm_path}");
 
+    println!("cargo:warning=Found jvm at {jvm_path}");
+
     // Add jvm.lib into search path for windows.
     if cfg!(windows) {
         if let Ok(jvm_lib_path) = java_locator::locate_file("jvm.lib") {

--- a/build.rs
+++ b/build.rs
@@ -28,10 +28,9 @@ fn find_jvm() -> Result<()> {
     println!("cargo:rustc-link-lib=jvm");
     println!("cargo:rustc-link-search=native={jvm_path}");
 
+    // For mac we need to manually add the jvm dir to rpath
     #[cfg(target_os = "macos")]
     println!("cargo:rustc-link-arg=-Wl,-rpath,{jvm_path}");
-
-    println!("cargo:warning=Found jvm at {jvm_path}");
 
     // Add jvm.lib into search path for windows.
     #[cfg(windows)]

--- a/build.rs
+++ b/build.rs
@@ -211,6 +211,12 @@ fn build_libhdfs() -> Result<()> {
         }
     }
 
+    #[cfg(not(feature = "vendored"))]
+    {
+        println!("cargo:warning=Building libhdfs from source as a fallback, \
+        if you are encountering issues with missing headers on JDK8, consider enabling the `vendored` feature.");
+    }
+
     builder.compile("hdfs");
     Ok(())
 }

--- a/build.rs
+++ b/build.rs
@@ -28,13 +28,15 @@ fn find_jvm() -> Result<()> {
     println!("cargo:rustc-link-lib=jvm");
     println!("cargo:rustc-link-search=native={jvm_path}");
 
+    #[cfg(target_os = "macos")]
+    println!("cargo:rustc-link-arg=-Wl,-rpath,{jvm_path}");
+
     println!("cargo:warning=Found jvm at {jvm_path}");
 
     // Add jvm.lib into search path for windows.
-    if cfg!(windows) {
-        if let Ok(jvm_lib_path) = java_locator::locate_file("jvm.lib") {
-            println!("cargo:rustc-link-search=native={jvm_lib_path}");
-        }
+    #[cfg(windows)]
+    if let Ok(jvm_lib_path) = java_locator::locate_file("jvm.lib") {
+        println!("cargo:rustc-link-search=native={jvm_lib_path}");
     }
 
     Ok(())

--- a/build.rs
+++ b/build.rs
@@ -28,10 +28,10 @@ fn find_jvm() -> Result<()> {
     println!("cargo:rustc-link-lib=jvm");
     println!("cargo:rustc-link-search=native={jvm_path}");
 
-    // For mac we need to manually add the jvm dir to rpath
-    #[cfg(target_os = "macos")]
+    // Add JVM to rpath
     println!("cargo:rustc-link-arg=-Wl,-rpath,{jvm_path}");
 
+    // Export the used JVM_PATH as metadata, in case a crate needs it in order to link
     println!("cargo:metadata=JVM_PATH={jvm_path}");
 
     // Add jvm.lib into search path for windows.

--- a/build.rs
+++ b/build.rs
@@ -79,7 +79,11 @@ fn build_libhdfs() -> Result<()> {
 
     let mut builder = cc::Build::new();
     builder.warnings(false);
+
+    // This flag does not work on windows, just throws warnings
+    #[cfg(not(windows))]
     builder.static_flag(true);
+
     builder.static_crt(true);
 
     // Ignore all warnings from cc as we don't care about code written by Apache Hadoop.

--- a/build.rs
+++ b/build.rs
@@ -32,6 +32,8 @@ fn find_jvm() -> Result<()> {
     #[cfg(target_os = "macos")]
     println!("cargo:rustc-link-arg=-Wl,-rpath,{jvm_path}");
 
+    println!("cargo:metadata=JVM_PATH={jvm_path}");
+
     // Add jvm.lib into search path for windows.
     #[cfg(windows)]
     if let Ok(jvm_lib_path) = java_locator::locate_file("jvm.lib") {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,10 +61,12 @@ pub use hdfs_2_3::*;
 #[cfg(feature = "hdfs_2_4")]
 mod hdfs_2_4;
 #[cfg(feature = "hdfs_2_4")]
+#[allow(unused_imports)]
 pub use hdfs_2_4::*;
 #[cfg(feature = "hdfs_2_5")]
 mod hdfs_2_5;
 #[cfg(feature = "hdfs_2_5")]
+#[allow(unused_imports)]
 pub use hdfs_2_5::*;
 #[cfg(feature = "hdfs_2_6")]
 mod hdfs_2_6;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,7 @@ pub use hdfs_2_7::*;
 #[cfg(feature = "hdfs_2_8")]
 mod hdfs_2_8;
 #[cfg(feature = "hdfs_2_8")]
+#[allow(unused_imports)]
 pub use hdfs_2_8::*;
 #[cfg(feature = "hdfs_2_9")]
 mod hdfs_2_9;
@@ -87,6 +88,7 @@ pub use hdfs_2_9::*;
 #[cfg(feature = "hdfs_2_10")]
 mod hdfs_2_10;
 #[cfg(feature = "hdfs_2_10")]
+#[allow(unused_imports)]
 pub use hdfs_2_10::*;
 #[cfg(feature = "hdfs_3_0")]
 mod hdfs_3_0;
@@ -95,10 +97,12 @@ pub use hdfs_3_0::*;
 #[cfg(feature = "hdfs_3_1")]
 mod hdfs_3_1;
 #[cfg(feature = "hdfs_3_1")]
+#[allow(unused_imports)]
 pub use hdfs_3_1::*;
 #[cfg(feature = "hdfs_3_2")]
 mod hdfs_3_2;
 #[cfg(feature = "hdfs_3_2")]
+#[allow(unused_imports)]
 pub use hdfs_3_2::*;
 #[cfg(feature = "hdfs_3_3")]
 mod hdfs_3_3;


### PR DESCRIPTION
This resolves an issue where header files are not found when compiling using the default JDK8 installation on Ubuntu(A problem which plague any JDK8 installation that does not set JAVA_HOME, I would presume), since `java-locator` was searching for the Java Runtime binary, which on JDK8 was in the `jre` subfolder instead of the JDK root, whose bin folder only held a symlink.
Using the `locate-jdk-only` feature, `java-locator` searches for the `javac` binary instead of `java`, which resolves this problem.
In order to not break the build for systems that only have the JRE installed and just want to link against libhdfs, I've attached the `locate-jdk-only` feature to the `vendored` feature, where we would need the JDK anyway.
This leaves an issue where the problem could still occur if libhdfs is not found and we only build it as a fallback, I've added a warning message there recommending enabling the "vendored" feature in case of header troubles.

You can read more in the java-locator PR:
https://github.com/astonbitecode/java-locator/pull/7